### PR TITLE
Create a default "tugboat" database

### DIFF
--- a/services/mysql/Dockerfile
+++ b/services/mysql/Dockerfile
@@ -3,6 +3,7 @@ COPY files/mysql/tugboat.cnf /etc/mysql/conf.d/tugboat.cnf
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_USER=tugboat \
     MYSQL_PASSWORD=tugboat \
+    MYSQL_DATABASE=tugboat \
     MYSQL_HOST=127.0.0.1 \
     MYSQL_ROOT_HOST=%
 


### PR DESCRIPTION
Users are still free to create any databases they like, but this adds a "tugboat" database that is always there, which they are also free to use. This means one less step is required in a build script.