### PR TITLE
Make default docroots symlinks, add DOCROOT envvar

### DIFF
--- a/services/httpd/Dockerfile
+++ b/services/httpd/Dockerfile
@@ -1,1 +1,6 @@
+ENV DOCROOT=/usr/local/apache2/htdocs
+
+RUN mv ${DOCROOT} ${DOCROOT}.original && \
+    ln -s ${DOCROOT}.original ${DOCROOT}
+
 HEALTHCHECK CMD /bin/nc -z 127.0.0.1 80

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,1 +1,6 @@
+ENV DOCROOT=/usr/share/nginx/html
+
+RUN mv ${DOCROOT} ${DOCROOT}.original && \
+    ln -s ${DOCROOT}.original ${DOCROOT}
+
 HEALTHCHECK CMD /bin/nc -z 127.0.0.1 80

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -1,4 +1,5 @@
-ENV COMPOSER_NO_INTERACTION=1
+ENV COMPOSER_NO_INTERACTION=1 \
+    DOCROOT=/var/www/html
 
 RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \
@@ -10,7 +11,10 @@ RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/mas
     mkdir -p /etc/service/apache && \
     echo "umask 0002" >> /etc/apache2/envvars && \
     sed -i 's|\(^\sErrorLog\s\).*|\1/proc/self/fd/2|' /etc/apache2/sites-available/000-default.conf && \
-    sed -i 's|\(^\sCustomLog\s\).*|\1/proc/self/fd/1 combined|' /etc/apache2/sites-available/000-default.conf
+    sed -i 's|\(^\sCustomLog\s\).*|\1/proc/self/fd/1 combined|' /etc/apache2/sites-available/000-default.conf && \
+    \
+    mv ${DOCROOT} ${DOCROOT}.original && \
+    ln -s ${DOCROOT}.original ${DOCROOT}
 
 COPY files/apache.runit /etc/service/apache/run
 HEALTHCHECK CMD /bin/nc -z 127.0.0.1 80


### PR DESCRIPTION
This allows build scripts to overwrite the symlink with `ln -sf`, and provides a uniform environment variable to find where each image expects to find the default docroot