### PR TITLE
Use a port check for MySQL-related services healthchecks

### DIFF
--- a/services/mariadb/Dockerfile
+++ b/services/mariadb/Dockerfile
@@ -7,4 +7,4 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_HOST=localhost \
     MYSQL_ROOT_HOST=localhost
 
-HEALTHCHECK CMD /usr/bin/mysqladmin ping
+HEALTHCHECK CMD /bin/nc -z 127.0.0.1 3306

--- a/services/mysql/Dockerfile
+++ b/services/mysql/Dockerfile
@@ -7,4 +7,4 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_HOST=localhost \
     MYSQL_ROOT_HOST=localhost
 
-HEALTHCHECK CMD mysql -e "show variables like 'version';"
+HEALTHCHECK CMD /bin/nc -z 127.0.0.1 3306

--- a/services/percona/Dockerfile
+++ b/services/percona/Dockerfile
@@ -7,4 +7,4 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_HOST=localhost \
     MYSQL_ROOT_HOST=localhost
 
-HEALTHCHECK CMD mysql -e "show variables like 'version';"
+HEALTHCHECK CMD /bin/nc -z 127.0.0.1 3306


### PR DESCRIPTION
When MySQL (and derivitaves) start up for the first time, there is an initialization script that runs. Part of that script includes starting up MySQL and running some SQL commands. The healthcheck commands we are currently using just wait for MySQL to be available from the command line. This healthcheck will pass before the database is fully initialized.

The initialization starts MySQL with --skip-networking, so it can do everything via a socket connection. Then, when it is done, it kills that instance and starts up an actual instance listening on the network like normal.

This PR changes the healthcheck to wait for port 3306 to respond, which will force Tugboat to wait until the initialization has finished.

Closes https://github.com/Lullabot/tugboat/issues/2832