### PR TITLE
Only build, but don't enable xdebug

### DIFF
--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     (pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.7.0beta1) && \
     bash -c "(pecl install mcrypt <<< '' || pecl install mcrypt-1.0.1 <<< '' || docker-php-ext-install mcrypt)" && \
-    docker-php-ext-enable xdebug mcrypt && \
+    docker-php-ext-enable mcrypt && \
     \
     php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \

--- a/services/php-fpm/Dockerfile
+++ b/services/php-fpm/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
     (pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.7.0beta1) && \
     bash -c "(pecl install mcrypt <<< '' || pecl install mcrypt-1.0.1 <<< '' || docker-php-ext-install mcrypt)" && \
-    docker-php-ext-enable xdebug mcrypt && \
+    docker-php-ext-enable mcrypt && \
     \
     php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \


### PR DESCRIPTION
Since xdebug isn't included in the base image, it makes sense to build it so it's ready to go for previews that want it. But otherwise, it should be opt-in to improve page load performance (xdebug simply being loaded double execution time).

I don't see a CHANGELOG.md or other way to document this change. Where should I do that so teams know about this change when they update their images?