### PR TITLE
Use memory caching instead of file caching

### DIFF
--- a/services/varnish/run
+++ b/services/varnish/run
@@ -5,5 +5,4 @@ exec docker-entrypoint.sh varnishd \
   -F \
   -a :80 \
   -T localhost:6082 \
-  -f /etc/varnish/default.vcl \
-  -s "file,/var/lib/varnish/varnish_storage.bin,1G"
+  -f /etc/varnish/default.vcl


### PR DESCRIPTION
Ubuntu defaults to a file cache, and it seemed like a good idea for previews. After all, it means that resuming previews would still have caches available.

However, this seems to be tricky with invalidating caches during builds. For some reason, Varnish is returning an error (empty content) until our Drupal container finishes building. I've spent some time debugging and haven't got anywhere, so it seems like the simplest solution is to use the default malloc caching in Varnish.