### PR TITLE
Remove centos6 images

### DIFF
--- a/services/centos/manifest
+++ b/services/centos/manifest
@@ -1,2 +1,3 @@
 NAME=centos
 TEMPLATE=yum
+FILTER="grep -v -e centos6"


### PR DESCRIPTION
from https://hub.docker.com/_/centos

> CentOS 6 binaries and/or libraries are built to expect some system calls to be accessed via vsyscall mappings. Some linux distributions have opted to disable vsyscall entirely (opting exclusively for more secure vdso mappings), causing segmentation faults.

Nobody is using the centos6 images, so removing them will not affect current users.