### PR TITLE
Use 256MB (half of free tier container limit) for cache

### DIFF
--- a/services/memcached/run
+++ b/services/memcached/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec docker-entrypoint.sh memcached -u memcache
+exec docker-entrypoint.sh memcached -u memcache -m 256


### PR DESCRIPTION
By default, the daemon is started with 64MB of memory, which is low enough to start running into evictions. Since even the free tier gives 512MB of memory per container, allowing half of that by default for memcache still seems conservative.