### PR TITLE
postgres requires POSTGRES_PASSWORD envvar now

### DIFF
--- a/services/postgres/Dockerfile
+++ b/services/postgres/Dockerfile
@@ -1,5 +1,6 @@
 COPY files/docker-entirypoint-initdb.d /docker-entrypoint-initdb.d
 
 ENV POSTGRES_DB=tugboat
+ENV POSTGRES_PASSWORD=tugboat
 
 HEALTHCHECK CMD /bin/nc -z 127.0.0.1 5432


### PR DESCRIPTION
Sets the default postgresql superuser password to `tugboat`

Affects #58 