### PR TITLE
fix: remove centos filter as 6 and 8 no longer are listed tags #96

### DIFF
--- a/services/centos/manifest
+++ b/services/centos/manifest
@@ -1,3 +1,2 @@
 NAME=centos
 TEMPLATE=yum
-FILTER="grep -v -e centos6 centos8"


### PR DESCRIPTION
Resolves #96 