### PR TITLE
Add imagick to php services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: $(ALL)
 $(SERVICES):
 	./generate $@
 	./build $@
-	./tags $@ > images/$@/TAGS.md
+	./tags $@
 
 elasticsearch:
 	./generate elasticsearch-dockerhub
@@ -25,7 +25,7 @@ php: php-nginx
 	./generate php-apache
 	./generate php-fpm
 	./build php
-	./tags php > images/php/TAGS.md
+	./tags php
 
 clean:
 	rm -rf images

--- a/services/php-apache/Dockerfile
+++ b/services/php-apache/Dockerfile
@@ -4,7 +4,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     WP_CLI_ALLOW_ROOT=1 \
     DOCROOT=/var/www/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev libmagickwand-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     docker-php-ext-configure gd --with-jpeg --with-freetype --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
@@ -12,6 +12,8 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \
     bash -c "(pecl install mcrypt <<< '' || pecl install mcrypt-1.0.1 <<< '' || docker-php-ext-install mcrypt || /bin/true)" && \
     (docker-php-ext-enable mcrypt || /bin/true)) || /bin/true) && \
+    ((pecl install --configureoptions 'with-imagick="autodetect"' imagick && \
+    docker-php-ext-enable imagick) || /bin/true) && \
     \
     php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \

--- a/services/php-fpm/Dockerfile
+++ b/services/php-fpm/Dockerfile
@@ -3,7 +3,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     COMPOSER_ALLOW_SUPERUSER=1 \
     WP_CLI_ALLOW_ROOT=1
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev libmagickwand-dev && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     docker-php-ext-configure gd --with-jpeg --with-freetype --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
@@ -11,6 +11,8 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \
     bash -c "(pecl install mcrypt <<< '' || pecl install mcrypt-1.0.1 <<< '' || docker-php-ext-install mcrypt || /bin/true)" && \
     (docker-php-ext-enable mcrypt || /bin/true)) || /bin/true) && \
+    ((pecl install --configureoptions 'with-imagick="autodetect"' imagick && \
+    docker-php-ext-enable imagick) || /bin/true) && \
     \
     php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \

--- a/services/php-nginx/Dockerfile
+++ b/services/php-nginx/Dockerfile
@@ -4,7 +4,7 @@ ENV COMPOSER_NO_INTERACTION=1 \
     WP_CLI_ALLOW_ROOT=1 \
     DOCROOT=/usr/share/nginx/html
 
-RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev nginx && \
+RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng-dev libwebp-dev libmagickwand-dev nginx && \
     (apt-get install -y mysql-client || apt-get install -y mariadb-client) && \
     docker-php-ext-configure gd --with-jpeg --with-freetype --with-webp && \
     docker-php-ext-install -j$(nproc) gd iconv pdo_mysql && \
@@ -12,6 +12,9 @@ RUN apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libmcrypt-dev libpng
     (((pecl install xdebug || pecl install xdebug-2.5.5 || pecl install xdebug-2.8.0beta2) && \
     bash -c "(pecl install mcrypt <<< '' || pecl install mcrypt-1.0.1 <<< '' || docker-php-ext-install mcrypt || /bin/true)" && \
     (docker-php-ext-enable mcrypt || /bin/true)) || /bin/true) && \
+    ((pecl install --configureoptions 'with-imagick="autodetect"' imagick && \
+    docker-php-ext-enable imagick) || /bin/true) && \
+    \
     php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/master/web/installer', 'composer-setup.php');" && \
     php composer-setup.php && \
     php -r "unlink('composer-setup.php');" && \

--- a/tags
+++ b/tags
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 
-DIR="images/$1"
+if [[ "$1" = "php-fpm" || "$1" = "php-apache" ]];then
+  DIR="images/php"
+else
+  DIR="images/$1"
+fi
 # mkdir -p won't yell if the directory is there already.
 mkdir -p "$DIR"
+out="$DIR/TAGS.md"
+echo "## Supported Tags for tugboatqa/$1" > $out
+echo "" >> $out
 
-echo "## Supported Tags for tugboatqa/$1"
-echo ""
+cat ${DIR}/*/TAGS | sort -r | sed 's/\ /`,\ `/g' | sed 's/^/*\ `/g' | sed 's/$/`/g' >> $out
 
-cat ${DIR}/*/TAGS | sort -r | sed 's/\ /`,\ `/g' | sed 's/^/*\ `/g' | sed 's/$/`/g'
-
-echo ""
-echo "The above tags are currently supported. Visit https://hub.docker.com/r/tugboatqa/$1/tags/ to see a list of all available tags for this image, including those that are no longer supported."
+echo "" >> $out
+echo "The above tags are currently supported. Visit https://hub.docker.com/r/tugboatqa/$1/tags/ to see a list of all available tags for this image, including those that are no longer supported." >> $out

--- a/tags
+++ b/tags
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 DIR="images/$1"
+# mkdir -p won't yell if the directory is there already.
+mkdir -p "$DIR"
 
 echo "## Supported Tags for tugboatqa/$1"
 echo ""


### PR DESCRIPTION
This merge request add the imagick image processing libraries to tugboatqa php services, since it is a fairly common alternative to gd in php applications. 


## Test
```
make php-apache
make php-fpm
make php-nginx
cd ./images/php 
for img in $(ls | grep -v TAGS); do
  docker run -it --rm tugboatqa/php:$img php -i | grep imagick
done

cd ../php-nginx
for img in $(ls | grep -v TAGS); do
  docker run -it --rm tugboatqa/php-nginx:$img php -i | grep imagick
done
```
Verify that every image generate php extension configuration information for imagick.

Resolves: #116

I also added a small fix to the `tags` command for edge cases like `make php-fpm` or `make php-apache` instead of `make php`.  Running make php-fpm, for example, previously would fail with 

> ./tags php-fpm > images/php-fpm/TAGS.md
> /bin/sh: images/php-fpm/TAGS.md: No such file or directory
> make: *** [php-fpm] Error 1

======
UPDATE:

^^ I made [another version of this merge request](https://github.com/TugboatQA/images/pull/123/files) without the "helpful/obfuscating" patches to tags and Makefile. You may prefer to just merge it instead.