### PR TITLE
fix: stop runit services gracefully #44

### DIFF
--- a/dist/runit-init.sh
+++ b/dist/runit-init.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+sv_stop() {
+    for s in /etc/service/*; do
+        "$RUNITDIR"/sv stop "$s"
+    done
+}
+
+# This should effectively be the same as setting SIGCHLD handler to SIG_IGN,
+# which allows for the kernel to reap child processes that terminate.
+trap "" SIGCHLD
+
+trap "sv_stop; exit" SIGTERM
+
+SVWAIT=60 "$RUNITDIR"/runsvdir -P /etc/service &
+wait

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -64,6 +64,11 @@ for tags in $($GETTAGS "${FILTER}"); do
         image="${FROM}:${tag}"
         mkdir -p "${imgdir}"
 
+        # Add the runit-init.sh if needed.
+        if [[ "$TEMPLATE" != "none" ]]; then
+            cp dist/runit-init.sh "${imgdir}"
+        fi
+
         RUN=""
         if [ -e "${dir}/run" ]; then
             cp "${dir}/run" "${imgdir}/run"

--- a/services/couchdb/run
+++ b/services/couchdb/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec tini -- /docker-entrypoint.sh /opt/couchdb/bin/couchdb
+exec /docker-entrypoint.sh /opt/couchdb/bin/couchdb

--- a/templates/Dockerfile.apk.template
+++ b/templates/Dockerfile.apk.template
@@ -10,4 +10,8 @@ RUN apk add --no-cache bash git openssh-client runit jq
 
 STOPSIGNAL SIGTERM
 
-CMD ["/sbin/runsvdir", "-P", "/etc/service"]
+ENV RUNITDIR=/sbin
+
+COPY runit-init.sh /runit-init.sh
+
+CMD ["/runit-init.sh"]

--- a/templates/Dockerfile.apt.template
+++ b/templates/Dockerfile.apt.template
@@ -50,4 +50,8 @@ RUN apt-get clean && \
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/bin/runsvdir", "-P", "/etc/service"]
+ENV RUNITDIR=/usr/bin
+
+COPY runit-init.sh /runit-init.sh
+
+CMD ["/runit-init.sh"]

--- a/templates/Dockerfile.yum.template
+++ b/templates/Dockerfile.yum.template
@@ -46,4 +46,8 @@ RUN yum clean all -y && \
 
 STOPSIGNAL SIGTERM
 
-CMD ["/usr/local/bin/runsvdir", "-P", "/etc/service"]
+ENV RUNITDIR=/usr/local/bin
+
+COPY runit-init.sh /runit-init.sh
+
+CMD ["/runit-init.sh"]


### PR DESCRIPTION
Resolves #44 

Please read that issue for details of the problem and replication instructions.

Inspired by https://github.com/peterbourgon/runsvinit/issues/3, this aims to solve the issue of stopping services gracefully when the docker container is stopped. 

### Testing instructions

1. run `docker run --rm  -it --name tb-test-mariadb-old docker.io/tugboatqa/mariadb`
2. Wait for logs to say that mariadb is ready for connections
3. In a separate window, run `docker stop tb-test-mariadb-old`
4. Note that the logs just end without gracefully shutting down mariadb
5. check out this branch
6. run `task -- mariadb`
7. run `docker run --rm  -it --name tb-test-mariadb-new tugboatqa/mariadb`
8. wait for logs to say that mariadb is ready for connections
9. in a separate window, run `docker stop tb-test-mariadb-new`
10. ensure that mariadb shuts down appropriately prior to the container stopping