### PR TITLE
Remove Centos7 image due to EOL

### DIFF
--- a/services/centos/manifest
+++ b/services/centos/manifest
@@ -1,2 +1,0 @@
-NAME=centos
-TEMPLATE=yum


### PR DESCRIPTION
This PR removes the Centos7 image, due to this operative system reached its end of life in June 30th, 2024.