### PR TITLE
#152 fix: alter RUNITDIR for alpine 3.21

### DIFF
--- a/templates/Dockerfile.apk.template
+++ b/templates/Dockerfile.apk.template
@@ -14,4 +14,10 @@ ENV RUNITDIR=/sbin
 
 COPY runit-init.sh /runit-init.sh
 
+# Alpine 3.21.* installs runit into a different directory. Test if this is 3.21
+# and then modify the above script appropriately.
+RUN source /etc/os-release && \
+    test "${VERSION_ID#3.21.}" = "$VERSION_ID" || \
+    sed -e 's@$RUNITDIR@/usr&@g' -i /runit-init.sh
+
 CMD ["/runit-init.sh"]


### PR DESCRIPTION
Resolves #152 

## Testing instructions

- Run `task -- alpine`
- `docker run --detach --rm tugboatqa/alpine:3.21.0`
- Then check the status of that container to see if it's healthy ^^
- When done, stop the container with `docker stop`