### PR TITLE
fix: respect PATH env variable for runitdir in alpine #152

### DIFF
--- a/dist/runit-init.sh
+++ b/dist/runit-init.sh
@@ -2,7 +2,7 @@
 
 sv_stop() {
     for s in /etc/service/*; do
-        "$RUNITDIR"/sv stop "$s"
+        "$RUNITDIR"sv stop "$s"
     done
 }
 
@@ -12,5 +12,5 @@ trap "" SIGCHLD
 
 trap "sv_stop; exit" SIGTERM
 
-SVWAIT=60 "$RUNITDIR"/runsvdir -P /etc/service &
+SVWAIT=60 "$RUNITDIR"runsvdir -P /etc/service &
 wait

--- a/templates/Dockerfile.apk.template
+++ b/templates/Dockerfile.apk.template
@@ -10,7 +10,7 @@ RUN apk add --no-cache bash git openssh-client runit jq
 
 STOPSIGNAL SIGTERM
 
-ENV RUNITDIR=/sbin
+ENV RUNITDIR=
 
 COPY runit-init.sh /runit-init.sh
 

--- a/templates/Dockerfile.apt.template
+++ b/templates/Dockerfile.apt.template
@@ -50,7 +50,7 @@ RUN apt-get clean && \
 
 STOPSIGNAL SIGTERM
 
-ENV RUNITDIR=/usr/bin
+ENV RUNITDIR=/usr/bin/
 
 COPY runit-init.sh /runit-init.sh
 

--- a/templates/Dockerfile.yum.template
+++ b/templates/Dockerfile.yum.template
@@ -46,7 +46,7 @@ RUN yum clean all -y && \
 
 STOPSIGNAL SIGTERM
 
-ENV RUNITDIR=/usr/local/bin
+ENV RUNITDIR=/usr/local/bin/
 
 COPY runit-init.sh /runit-init.sh
 


### PR DESCRIPTION
An alternate solution to #152 

Resolves #152

## Testing instructions:

- `task -- alpine`
- Then run each tag created to see if they are healthy:

```
$ image=tugboatqa/alpine:3.20.3

$ container=$(docker run --detach --rm $image)

$ docker ps --filter "id=$container" --format "{{ .State }}"
running

$ docker rm -f $container
```