### PR TITLE
Update local environment to use Debian 12 Bookworm

### DIFF
--- a/Vagrant.yml
+++ b/Vagrant.yml
@@ -2,7 +2,7 @@ vb:
 
   ## Which vagrant box to use. A Debian-based image is assumed by the
   ## provisioning scripts.
-  box: debian/contrib-buster64
+  box: generic/debian12
 
   ## Which type of network to use to access the VMs. Use "public_network" if
   ## you want bridged interfaces to your local network.
@@ -23,7 +23,7 @@ vb:
   ## Providers' file sharing method. Other valid values include nfs, smb, or
   ## rsync. See http://docs.vagrantup.com/v2/synced-folders/index.html for more
   ## information.
-  sync: ''
+  sync: virtualbox
 
   ## If defined, this public key is added to the vagrant user's authorized_keys
   ## file automatically.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ require 'yaml'
 
 dir = File.dirname(File.expand_path(__FILE__))
 settings = YAML::load_file("#{dir}/Vagrant.yml")
-if File.exists?("#{dir}/Vagrant.local.yml")
+if File.exist?("#{dir}/Vagrant.local.yml")
     local = YAML::load_file("#{dir}/Vagrant.local.yml")
     settings["vb"].merge!(local["vb"])
 end
@@ -26,7 +26,12 @@ apt-get install -yq \
     curl \
     git \
     jq \
+    parallel \
+    pipx \
     software-properties-common
+
+pipx install go-task-bin
+ln -snf /root/.local/bin/task /usr/local/bin/task
 SCRIPT
 
 $docker = <<SCRIPT
@@ -69,6 +74,9 @@ Vagrant.configure(2) do |config|
 
     config.vm.provision "shell", inline: $packages
     config.vm.provision "shell", inline: $docker
+
+    ## Synced folders
+    config.vm.synced_folder ".", "/vagrant", type: settings["vb"]["sync"]
 
     # Add defined SSH public key to vagrant user's authorized_keys
     if settings["vb"]["sshkey"]


### PR DESCRIPTION
This PR does the following:

* Upgrade the Vagrant box to use Debian 12 Bookworm
* Ensures the code is mounted within the virtual machine
* Ensures Taskfile and GNU Parallel are installed
* Fixes a syntax error