### PR TITLE
#155 chore: ensure postgis runs action to free disk space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         # Some of our services need a lot of free disk. We run this action to
         # free up some disk space, however it is slow, so we conditionally do
         # this only on those services that need it.
-        if: matrix.service == 'opensearch' || matrix.service == 'dynamodb'
+        if: matrix.service == 'opensearch' || matrix.service == 'dynamodb' || matrix.service == 'postgis'
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get update


### PR DESCRIPTION
Allow build action to run the free disk space action when building the `postgis` service 

From the `postgis` service build logs:
```
images/postgis/12-3.5/image.tar	write /var/lib/docker/image/overlay2/layerdb/tmp/write-set-42354598/diff: no space left on device
images/postgis/13-3.5/image.tar	write /usr/lib/x86_64-linux-gnu/libformw.so.6.2: no space left on device
images/postgis/12-3.4/image.tar	write /usr/lib/x86_64-linux-gnu/libkmldom.so.1.3.0: no space left on device
images/postgis/13-3.4/image.tar	write /usr/lib/x86_64-linux-gnu/libfyba.so.0.0.0: no space left on device
```