### PR TITLE
#155 fix: Use blank Dockerfile template for Percona service

### DIFF
--- a/services/percona/Dockerfile
+++ b/services/percona/Dockerfile
@@ -1,5 +1,7 @@
 COPY files/mysql/tugboat.cnf /etc/my.cnf.d/tugboat.cnf
 
+RUN cd /var/lib/mysql && mysqld --initialize --user=mysql
+
 ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_USER=tugboat \
     MYSQL_PASSWORD=tugboat \
@@ -7,4 +9,4 @@ ENV MYSQL_ALLOW_EMPTY_PASSWORD=true \
     MYSQL_HOST=localhost \
     MYSQL_ROOT_HOST=localhost
 
-HEALTHCHECK CMD /bin/nc -z 127.0.0.1 3306
+HEALTHCHECK CMD /usr/bin/true &>/dev/null </dev/tcp/127.0.0.1/3306

--- a/services/percona/files/mysql/tugboat.cnf
+++ b/services/percona/files/mysql/tugboat.cnf
@@ -1,14 +1,14 @@
 [mysqld]
-collation-server = utf8_unicode_ci
+collation-server = utf8mb4_unicode_ci
 init-connect = "SET NAMES utf8"
-character-set-server = utf8
+character-set-server = UTF8MB4
 sync_binlog = 0
 skip-log-bin
-
 default_storage_engine = innodb
+
 innodb_flush_log_at_trx_commit = 2
 innodb_log_buffer_size         = 8M
-innodb_log_file_size           = 5242880
+innodb_redo_log_capacity       = 10485760
 innodb_buffer_pool_size        = 134217728
 innodb_use_native_aio          = 0
 innodb_file_per_table

--- a/services/percona/manifest
+++ b/services/percona/manifest
@@ -1,5 +1,5 @@
 NAME=percona
 FROM=percona
-TEMPLATE=yum
+TEMPLATE=none
 # Filter out centos 5.6 and percona with mongodb.
 FILTER="grep -v -e 5.6-centos -e psmdb"

--- a/templates/Dockerfile.none.template
+++ b/templates/Dockerfile.none.template
@@ -1,1 +1,5 @@
+FROM {{FROM}}
+
+USER root
+
 {{DOCKERFILE}}

--- a/templates/Dockerfile.none.template
+++ b/templates/Dockerfile.none.template
@@ -1,5 +1,3 @@
 FROM {{FROM}}
 
-USER root
-
 {{DOCKERFILE}}


### PR DESCRIPTION
The problem with Percona build is neither `yum` nor `dnf` are available - only `rpm`. This is because the `percona:8.0.41-32` image, used as source, is created from [redhat/ubi9-minimal](https://github.com/percona/percona-docker/blob/73ddc25d7165fa77bda3e92191ec2fc5536c500a/percona-server-8.0/Dockerfile-dockerhub#L6), which does not include those tools.

The proposed solution is to change the Dockerfile template from `yum` to `none`. I also had to add the `FROM` and `USER` variables to the `none` Dockerfile template, because compilation fails if they are not present.