### PR TITLE
fix: free up disk space on node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         # Some of our services need a lot of free disk. We run this action to
         # free up some disk space, however it is slow, so we conditionally do
         # this only on those services that need it.
-        if: matrix.service == 'opensearch' || matrix.service == 'dynamodb' || matrix.service == 'postgis'
+        if: matrix.service == 'opensearch' || matrix.service == 'dynamodb' || matrix.service == 'postgis' || matrix.service == 'node'
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get update


### PR DESCRIPTION
Problem

  The node service build fails in GitHub Actions with the following error:

  parallel: Error: Output is incomplete.
  parallel: Error: Cannot append to buffer file in /home/runner/work/_temp.
  parallel: Error: Is the disk full?
  task: Failed to run task "default": exit status 255

  Root Cause

  The node service generates 12 image tarballs (versions 20, 22, 24, 25 across multiple Debian variants). During the task build step, GNU Parallel runs scripts/build.sh on all tarballs concurrently at 100% parallelism.

  Each build.sh execution:
  1. Reads the original tarball from disk
  2. Extracts the tarball to a temporary directory in $TMPDIR
  3. Loads the extracted image into Docker's storage
  4. The tarball is only deleted after the image is successfully loaded

  With 12 images running in parallel, the combined disk usage of tarballs, extracted temporary files, and loaded Docker images exceeds available disk space on the GitHub runner, causing the build to fail.