### PR TITLE
fix: only filter versions 9.*.* and not all 9s

### DIFF
--- a/services/elasticsearch-dockerhub/manifest
+++ b/services/elasticsearch-dockerhub/manifest
@@ -2,4 +2,4 @@ NAME=elasticsearch
 FROM=elasticsearch
 SERVICE=elasticsearch
 # Version 9.x is RHEL ubi9-minimal, lower versions are Ubuntu.
-FILTER="grep -v -e 9\."
+FILTER="grep -v -e '^9\.'"

--- a/services/elasticsearch-dockerhub/manifest
+++ b/services/elasticsearch-dockerhub/manifest
@@ -2,4 +2,4 @@ NAME=elasticsearch
 FROM=elasticsearch
 SERVICE=elasticsearch
 # Version 9.x is RHEL ubi9-minimal, lower versions are Ubuntu.
-FILTER="grep -v -e '^9\.'"
+FILTER="grep -v -e ^9\."


### PR DESCRIPTION
This fixes the issue of this filter filter out all tags with 9s in them when instead we want to filter only 9.*.*