### PR TITLE
fix: skip debian forky until QEMU arm64 systemd 260 works #179

### DIFF
--- a/services/debian/manifest
+++ b/services/debian/manifest
@@ -1,2 +1,2 @@
-FILTER="grep -v -e backports -e oldstable -e sid -e rc -e experimental -e unstable -e testing"
+FILTER="grep -v -e backports -e oldstable -e sid -e rc -e experimental -e unstable -e testing -e forky"
 PLATFORMS=linux/amd64,linux/arm64


### PR DESCRIPTION
## Summary

- Fixes #179. Forky pulls in `systemd 260.1-1`, whose arm64 postinst crashes QEMU user-mode emulation on the amd64 GitHub runners (`qemu-aarch64: QEMU internal SIGSEGV`), which then cascades through `systemd-timesyncd`, `dbus`, `dbus-system-bus-common`, and `openssh-client` and fails the weekly `Build service (debian)` job.
- Add `-e forky` to the existing `services/debian/manifest` filter so forky is skipped until upstream QEMU/binfmt or the Debian systemd package fixes the postinst crash.
- Bullseye, bookworm, and trixie are unaffected — they don't pull systemd 260 yet.
- Re-enabling forky is tracked in #180.

Example failing run: https://github.com/TugboatQA/images/actions/runs/25947910358 (job `Build service (debian)`).

## Test plan

- [ ] Trigger the `build` workflow manually and confirm `Build service (debian)` completes successfully.
- [ ] Confirm no `forky*` target appears in the bake matrix for that run.
- [ ] Confirm `tugboatqa/debian:bullseye`, `:bookworm`, `:trixie`, and their `-linux-arm64` variants are still pushed.