### PR TITLE
fix: skip deleted services in PR test matrix #182

### DIFF
--- a/.github/workflows/detect-pr-services.sh
+++ b/.github/workflows/detect-pr-services.sh
@@ -6,4 +6,7 @@ git diff --name-only origin/main | \
     sed -e 's@^services/@@g' | \
     sort | \
     uniq | \
+    while read -r service; do
+        [[ -d "services/$service" ]] && echo "$service"
+    done | \
     xargs echo


### PR DESCRIPTION
## Summary

- Fixes #182. `.github/workflows/detect-pr-services.sh` derived the list of services to test from `git diff --name-only origin/main`, which includes paths for files deleted in the PR. As a result, removing a service directory put its name into the test matrix and `task -- <service>` failed its existence precondition.
- Add a filter that keeps only service names whose `services/<name>/` directory is still present in the working tree (i.e. not deleted on this PR branch).
- Surfaced on #178, where deleting `services/mysql-oraclelinux/` caused a `Test service (mysql-oraclelinux)` job to fail with `task: services/mysql-oraclelinux does not exist`. After this lands and #178 is rebased, that phantom job will no longer be scheduled.

## Test plan

- [ ] Confirm `Detect PR services` on this PR outputs an empty list (this PR only changes a `.github/workflows/` script, not any `services/*` dir) and no `Test service (...)` jobs are scheduled.
- [ ] Rebase #178 on top of this and confirm only `Test service (mysql)` runs — `mysql-oraclelinux` is no longer in the matrix.
- [ ] Confirm a PR that *modifies* an existing service (e.g. edits a manifest) still produces that service in the matrix.